### PR TITLE
Change toctree to include subsections

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -67,9 +67,11 @@ future reference.
 
 **Table of Contents**
 
+see :ref:`sitemap`
+
 .. toctree::
    :maxdepth: 5
-   :titlesonly:
+   :hidden:
    :glob:
 
    Introduction/Index
@@ -82,4 +84,5 @@ future reference.
    OtherBackendModules/Index
    Troubleshooting/Index
    NextSteps/Index
+   Sitemap
    Targets

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,0 +1,11 @@
+:template: sitemap.html
+
+.. _sitemap:
+
+=======
+Sitemap
+=======
+
+.. template 'sitemap.html' will insert the toctree as a sitemap here
+below normal contents
+


### PR DESCRIPTION
- Remove titlesonly from toctree on startpage to include subsections in main menu
- Add sitemap

Resolves: #32