### PR TITLE
Add note about support for pdf and ai reading

### DIFF
--- a/Documentation/Troubleshooting/ImageProcessing/Index.rst
+++ b/Documentation/Troubleshooting/ImageProcessing/Index.rst
@@ -15,3 +15,12 @@ For more help on the topic, please refer to the
 :ref:`Installation Guide <t3install:start>`.
 
 You could also ask for help in the `installation forums <https://forum.typo3.org/index.php/i/6/>`_.
+
+.. note::
+   Please be aware that converting/reading of PDF and AI files is actually no
+   more possible because GraphicsMagic and ImageMagick recently dropped this 
+   functionality for security reasons. 
+
+   See the issues https://forge.typo3.org/issues/86368 and https://forge.typo3.org/issues/86369
+   for further details, where a workaround is also present.
+


### PR DESCRIPTION
as written on https://forge.typo3.org/issues/86368 and https://forge.typo3.org/issues/86369 Graphicsmagic and Imagemagick dropped the support for reading/converting PDF and AI, so the corresponding tests in the Install Tool always fail. I add a note about this situation