### PR TITLE
Improve readability of Administrators page

### DIFF
--- a/Documentation/NextSteps/Administrators/Index.rst
+++ b/Documentation/NextSteps/Administrators/Index.rst
@@ -8,14 +8,16 @@
 For Integrators
 ===============
 
+The role of a TYPO3 Integrator is that of someone who's responsibilities 
+include the installation, configuration and ongoing maintenance of a TYPO3
+based website.
+
+Below are several examples of common tasks required By Integrators.
 
 .. tip::
 
-   Read `TYPO3 CMS Certified Integrator <https://typo3.org/certification/integrator/>`__
-   to learn what the TYPO3 Association defines as integrator.
-
-If you want to learn how to professionally setup or maintain TYPO3 websites,
-you can look at the following resources:
+   Visit the `TYPO3 CMS Certified Integrator <https://typo3.org/certification/integrator/>`__
+   page to find out more about what is required to become an certified TYPO3 CMS Integrator.
 
 .. _site-handling:
 
@@ -27,15 +29,15 @@ You can:
 * setup several websites in one TYPO3 installation
 * setup several languages for each site
 
-Before TYPO3 9, it was necessary to setup the language configuration for each
-site manually with TypoScript.
+TYPO3 9 comes with a powerful site handling module which is documented in
+:ref:`t3coreapi:sitehandling`. This module allows you to set up multiple sites 
+in a single instance of TYPO3, configure multiple languages for your site and 
+it also manages URL handling for your sites. 
 
-TYPO3 9 comes with a powerful site handling module which is document in
-:ref:`t3coreapi:sitehandling`. This includes, setting up sites, language configuration
-and URL handlling. Find out more about URL handling in the next section.
+You can find out more about URL handling in the next section.
 
-Even if you only use one language or only one site, it is recommended to setup
-the site configuration. You can find it in the backend under :guilabel:`SITE MANAGEMENT`:
+Even if you use one language or only one site in your project, it is recommended you visit
+the site handling module. You can find it in the backend under :guilabel:`SITE MANAGEMENT`:
 :guilabel:`Sites`.
 
 .. image:: ../../Images/SiteManagement.png
@@ -58,13 +60,13 @@ Starting with version 9.5, human-readable URLs are created automatically by TYPO
 This functionality is available for pages, languages and also extensions.
 The documentation is available in "TYPO3 Explained" :ref:`t3coreapi:sitehandling`.
 
-Other tutorials like
+Other tutorials include
 `TYPO3 Worx: TYPO3 Site Management and Routing <https://typo3worx.eu/2018/10/typo3-site-management-and-routing/>`__
 and
 `TYPO3 Worx: TYPO3 Routing: Extensions and Enhancers <https://typo3worx.eu/2018/12/typo3-routing-extensions-and-enhancers/>`__
 are also available.
 
-For previous TYPO3 versions, this functionality was provided by third party extensions like
+For previous TYPO3 versions, this functionality was provided by third party extensions such as
 `realurl <https://extensions.typo3.org/extension/realurl/>`__.
 
 Thus, the URL as mentioned earlier becomes for example
@@ -83,9 +85,9 @@ The Introduction Package is a distribution. Find out more about distributions
 in "TYPO3 Explained": :ref:`t3coreapi:distribution`.
 
 The Introduction Package together with the Bootstrap Package provides
-a frontend layout based on bootstrap, adds configuration
-and creates some initial pages and content. While this is useful for quickly
-setting up a full-blown TYPO3 website, you will probably want to create a
+a frontend layout based on Bootstrap, which is preconfigured
+and creates some example pages with content. While this is useful for quickly
+setting up a demo website, you will probably want to create a
 custom theme for your own site.
 
 A good approach is to bundle everything for your site including a theme
@@ -93,7 +95,7 @@ and configuration into a sitepackage.
 
 Read the :ref:`t3sitepackage:start` to learn how to do this.
 
-Or watch this 3 part video series from the official TYPO3 YouTube channel:
+Or watch this three part video series from the official TYPO3 YouTube channel:
 
 .. youtube:: HtBmim7pc0o
 
@@ -107,9 +109,9 @@ Or watch this 3 part video series from the official TYPO3 YouTube channel:
 TypoScript
 ==========
 
-While the already mentioned :ref:`t3sitepackage:start` teaches you the TypoScript
-you need to create a sitepackage, it is not a bad idea to get yourself a
-TypoScript introduction.
+While the :ref:`t3sitepackage:start` teaches you the TypoScript 
+required to create a sitepackage, it is not a bad idea to get yourself 
+more familiar with TypoScript first.
 
 :ref:`TypoScript in 45 Minutes <t3ts45:start>` guides you through the
 basics of *TypoScript*.
@@ -120,12 +122,11 @@ Fluid
 =====
 
 In the :ref:`t3sitepackage:start` you will also have acquired a working knowledge
-of Fluid, the templating engine. To learn more about Fluid, you may want to
-use the following resources:
+of Fluid, the templating engine. To learn more about Fluid, you can visit 
+the following resources:
 
 * `Fluid documentation <https://github.com/TYPO3/Fluid>`__: As Fluid itself can be
   used independently to TYPO3, it is developed outside of the TYPO3 project. This
   is the start page of the Fluid project.
 * :ref:`t3extbasebook:fluid-start` in the "Extbase / Fluid Book"
 * :ref:`t3viewhelper:start`
-


### PR DESCRIPTION
This commit is intended to improve the readability of the Administrators page.

- Better define the role of an Integrator
- Remove references to the "old ways" of URL handling in previous versions of TYPO3