### PR TITLE
Set max_line_length to 80 in .editorconfig as should be the standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 3
+max_line_length = 80
 
 # MD-Files
 [*.md]


### PR DESCRIPTION
(see https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/CodingGuidelines.html?highlight=editorconfig)