### PR TITLE
Add note to inverting allow/deny behavior fields

### DIFF
--- a/Documentation/UserManagement/GroupPermissions/Index.rst
+++ b/Documentation/UserManagement/GroupPermissions/Index.rst
@@ -126,11 +126,9 @@ making changes.
    
 .. note::
 
-   **Inverting the behavior**
-
-   You can change the behavior of this setting in the install tool 
-   [BE][explicitADmode] = explicitDeny
-   This can be helpful on updating TYPO3 and still using the old permissions.
+   You can change the behavior in the install tool by setting
+   :ref:`[BE][explicitADmode]<t3coreapi:globals-typo3-conf-vars-be-explicitadmode>` 
+   to :php:`explicitDeny`.
 
 Limit to Languages
 ------------------

--- a/Documentation/UserManagement/GroupPermissions/Index.rst
+++ b/Documentation/UserManagement/GroupPermissions/Index.rst
@@ -123,7 +123,14 @@ making changes.
 
 .. figure:: ../../Images/BackendBackendGroupEditAllowDeny.png
    :alt: Setting permissions for values of the content type field
+   
+.. note::
 
+   **Inverting the behavior**
+
+   You can change the behavior of this setting in the install tool 
+   [BE][explicitADmode] = explicitDeny
+   This can be helpful on updating TYPO3 and still using the old permissions.
 
 Limit to Languages
 ------------------


### PR DESCRIPTION
Add note to inverting the behavior of allow/deny fields in Localconfiguration.php
That note was already there in older version (6.2) but not in following versions. 
I'm searched for that after an update to still use the old settings for that.