### PR TITLE
[TASK] Update nginx configuration

### DIFF
--- a/Documentation/SystemRequirements/NGINX.rst.txt
+++ b/Documentation/SystemRequirements/NGINX.rst.txt
@@ -82,6 +82,15 @@ Example NGINX configuration file:
    location / {
        try_files $uri $uri/ /index.php$is_args$args;
    }
+   
+   location = /typo3 {
+       rewrite ^ /typo3/;
+   }
+
+   location /typo3/ {
+       absolute_redirect off;
+       try_files $uri /typo3/index.php$is_args$args;
+   }
 
    location ~ [^/]\.php(/|$) {
        fastcgi_split_path_info ^(.+?\.php)(/.*)$;


### PR DESCRIPTION
In order to work with TYPO3 11.5, rewrite rules for files within /typo3 needs to be configured.
Otherwise the backend is never accessible.

See: https://github.com/drud/ddev/blob/a1b9ee4f8e8e2c6bb04b3a9e93e361c2040e8477/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf#L31