### PR TITLE
[BUGFIX] remove typo3temp/ from shared folders

### DIFF
--- a/Documentation/Installation/DeployTYPO3.rst
+++ b/Documentation/Installation/DeployTYPO3.rst
@@ -74,7 +74,6 @@ This is an exemplatory directory structure of a "symlink-switching" TYPO3 instal
 
     ├── shared/
     │    ├── fileadmin/
-    │    ├── typo3temp/
     │    └── var/
     │        ├── var/charset/
     │        ├── var/lock/


### PR DESCRIPTION
This removes `shared/typo3temp` which is not used