### PR TITLE
[SECURITY] Add information for logging

### DIFF
--- a/Documentation/Installation/DeployTYPO3.rst
+++ b/Documentation/Installation/DeployTYPO3.rst
@@ -45,12 +45,8 @@ To ensure a secure installation of TYPO3 on a production server, the following s
 - :guilabel:`Admin Tools > Settings > Configuration Presets` The "Live" preset has to be chosen to make sure no debug output is displayed.
 - `HTTPS` should be used on production servers and :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']` should be set to `true`.
 - The `TYPO3_CONTEXT` environment variable should be set to a main context of `Production` (can be verified on the top right in the TYPO3 backend :guilabel:`Application Information`). It should be used to select the appropriate `base variant` for the target system in the Site Configuration.
-- Make sure to configure the :ref:`TYPO3 logging framework <t3coreapi:logging-configuration>` to log only log messages of high severity
-  (e.g. including and above WARNING or ERROR) and regularly cleanup the log files (in :file:`var/log` for Composer based installations) automatically,
-  e.g.by using logrotate.
-
-Additionally, verify the :ref:`file permissions <t3coreapi:security-file-directory-permissions>` on the live system.
-
+- Configure the :ref:`TYPO3 logging framework <t3coreapi:logging-configuration>` to log messages of high severity including and above WARNING or ERROR
+  and continue rotate log files stored in :file:`var/log`.
 
 Deployment Automation
 =====================

--- a/Documentation/Installation/DeployTYPO3.rst
+++ b/Documentation/Installation/DeployTYPO3.rst
@@ -45,6 +45,9 @@ To ensure a secure installation of TYPO3 on a production server, the following s
 - :guilabel:`Admin Tools > Settings > Configuration Presets` The "Live" preset has to be chosen to make sure no debug output is displayed.
 - `HTTPS` should be used on production servers and :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']` should be set to `true`.
 - The `TYPO3_CONTEXT` environment variable should be set to a main context of `Production` (can be verified on the top right in the TYPO3 backend :guilabel:`Application Information`). It should be used to select the appropriate `base variant` for the target system in the Site Configuration.
+- Make sure to configure the :ref:`TYPO3 logging framework <t3coreapi:logging-configuration>` to log only log messages of high severity
+  (e.g. including and above WARNING or ERROR) and regularly cleanup the log files (in :file:`var/log` for Composer based installations) automatically,
+  e.g.by using logrotate.
 
 Additionally, verify the :ref:`file permissions <t3coreapi:security-file-directory-permissions>` on the live system.
 

--- a/Documentation/Installation/DeployTYPO3.rst
+++ b/Documentation/Installation/DeployTYPO3.rst
@@ -47,6 +47,8 @@ To ensure a secure installation of TYPO3 on a production server, the following s
 - The `TYPO3_CONTEXT` environment variable should be set to a main context of `Production` (can be verified on the top right in the TYPO3 backend :guilabel:`Application Information`). It should be used to select the appropriate `base variant` for the target system in the Site Configuration.
 - Configure the :ref:`TYPO3 logging framework <t3coreapi:logging-configuration>` to log messages of high severity including and above WARNING or ERROR
   and continue rotate log files stored in :file:`var/log`.
+  
+ In addition, verify the :ref:`file permissions <t3coreapi:security-file-directory-permissions>` are correct on the live system.
 
 Deployment Automation
 =====================


### PR DESCRIPTION
Recommend using logging severity including WARNING or higher
for production.

Related: TYPO3-Documentation/TYPO3CMS-Reference-CoreApi#351
Releases: master, 11.5