### PR TITLE
Update Install.rst - 'docroot' MUST be 'public'

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -79,6 +79,7 @@ Execute Composer Create-Project
            cd example-project-directory
 
            # Tell DDEV to create a new project of type "typo3"
+           # 'docroot' MUST be 'public'
            ddev config  --project-type=typo3 --docroot=public --create-docroot
 
            # Start the ddev instance


### PR DESCRIPTION
People should know that they can't use a different value for 'docroot'. 
See also:
* https://github.com/TYPO3/get.typo3.org/issues/291
* https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/issues/54
* https://github.com/drud/ddev/issues/3701