### PR TITLE
[BUGFIX] Add Link to --no-dev option

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -30,7 +30,7 @@ Deployment to the productive system can be achieved by deploying these two
    composer install --no-dev
 
 .. warning::
-   Always use the `--no-dev <https://getcomposer.org/doc/03-cli.md#install-i>`__ parameter to prevent installing packages marked as
+   Always use the `--no-dev <https://getcomposer.org/doc/03-cli.md#install-i>`__ option to prevent installing packages marked as
    "development only" to be deployed on the productive server.
 
 Or by executing the above command on a development system or in a Docker container

--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -30,7 +30,7 @@ Deployment to the productive system can be achieved by deploying these two
    composer install --no-dev
 
 .. warning::
-   Always use the :sh:`--no-dev` parameter to prevent installing packages marked as
+   Always use the `--no-dev <https://getcomposer.org/doc/03-cli.md#install-i>`__ parameter to prevent installing packages marked as
    "development only" to be deployed on the productive server.
 
 Or by executing the above command on a development system or in a Docker container


### PR DESCRIPTION
The current format shows the :sh: markup in the frontend