### PR TITLE
[DOCS] Provide correct commands for bash/powershell/ddev

### DIFF
--- a/Documentation/IntroductionPackage/Index.rst
+++ b/Documentation/IntroductionPackage/Index.rst
@@ -31,17 +31,49 @@ Installing The Introduction Package
 
 To install the Introduction Package run the following command:
 
-.. code-block:: shell
+.. tabs::
 
-   composer require typo3/cms-introduction
+   .. group-tab:: bash
+
+       .. code-block:: bash
+
+         composer require typo3/cms-introduction
+
+   .. group-tab:: powershell
+
+       .. code-block:: powershell
+
+         composer require typo3/cms-introduction
+
+   .. group-tab:: ddev
+
+       .. code-block:: bash
+
+         ddev composer require typo3/cms-introduction
 
 This command will download and activate the extension.
 
 Then run:
 
-.. code-block:: shell
+.. tabs::
 
-   extension:setup
+   .. group-tab:: bash
+
+       .. code-block:: bash
+
+         vendor/bin/typo3 extension:setup
+
+   .. group-tab:: powershell
+
+       .. code-block:: powershell
+
+         vendor/bin/typo3 extension:setup
+
+   .. group-tab:: ddev
+
+       .. code-block:: bash
+
+         ddev typo3 extension:setup
 
 This will set up the extension ready for immediate use.
 


### PR DESCRIPTION
* Add installation-type-specific instructions for the CLI commands.
* Add full path to typo3 CLI (`vendor/bin/typo3`)
* Specify the exact DDEV CLI command (`ddev composer ...` and `ddev typo3 ...`)

Fixes #188 