### PR TITLE
[TASK] Remove version number for get.typo3.org

### DIFF
--- a/Documentation/SystemRequirements/Index.rst
+++ b/Documentation/SystemRequirements/Index.rst
@@ -13,7 +13,7 @@ TYPO3 requires a web server running PHP and access to a database.
 Composer is also required for local development.
 
 For up-to-date information about TYPO3's system requirements visit `get.typo3.org
-<https://get.typo3.org/version/11#system-requirements>`_.
+<https://get.typo3.org/version/#system-requirements>`_.
 
 .. include:: PHP.rst.txt
 


### PR DESCRIPTION
This will redirect to the latest release. Removing the
version number from the URL removes necessity to update
this page for every version.