### PR TITLE
Remove required mod_autoindex

### DIFF
--- a/Documentation/SystemRequirements/Apache.rst.txt
+++ b/Documentation/SystemRequirements/Apache.rst.txt
@@ -18,9 +18,6 @@ mod_alias:
 mod_authz_core:
    Block access to specific files and directories
 
-mod_autoindex:
-   Used for disabling directory listings
-
 mod_deflate:
    Used for compression and performance.
 


### PR DESCRIPTION
The module is NOT required for TYPO3. In fact, in the
default TYPO3 .htaccess directory listings are disabled:

`<IfModule mod_autoindex.c>`
        Options -Indexes
`</IfModule>`

The module mod_autoindex is not required to disable the
directoriy listings. It provides the directory listings
in the first place (which can then be disabled).

So, if one wants to add the module, they can, but it is
not a requirement for TYPO3.