### PR TITLE
Clarify section on Apache modules

### DIFF
--- a/Documentation/SystemRequirements/Apache.rst.txt
+++ b/Documentation/SystemRequirements/Apache.rst.txt
@@ -10,7 +10,12 @@ During the initial installation, TYPO3's default :file:`.htaccess` file is copie
 
 **Apache Modules**
 
-The following Apache modules are required:
+The following Apache modules are required. The list is based on what is used in
+the default TYPO3
+`.htaccess <https://github.com/TYPO3/typo3/blob/main/typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess>`__.
+In some cases, it is not a "hard" requirement, but is strongly recommended for
+security or performance reasons, but you can also handle the desired outcome
+in a different way with a different module.
 
 mod_alias:
    Block access to vcs directories


### PR DESCRIPTION
The previous text was slightly misleading because not all modules
are a requirement for TYPO3. But the current modules are used
in the default .htaccess. Addressing this and adding a link
to the .htaccess file in the core makes it more clear and makes
it easier for people to followup and check the requirements
and how they are used - even if they have not yet installed
TYPO3.