### PR TITLE
Move meta information to the bottom of the landing page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -4,24 +4,6 @@
 TYPO3 - Getting Started Tutorial
 ================================
 
-:Version:
-   |release|
-
-:Language:
-   en
-
-:Author:
-   TYPO3 contributors
-
-:License:
-   This document is published under the
-   `Open Publication License <https://www.opencontent.org/openpub/>`__.
-
-:Rendered:
-   |today|
-
-----
-
 Welcome to Getting Started, this guide features an introduction to TYPO3 that
 highlights some of its core concepts including the backend administrative
 interface.
@@ -159,6 +141,24 @@ installed.
   UserManagement/Index
   IntroductionPackage/Index
   NextSteps/Index
+
+----
+
+:Version:
+   |release|
+
+:Language:
+   en
+
+:Author:
+   TYPO3 contributors
+
+:License:
+   This document is published under the
+   `Open Publication License <https://www.opencontent.org/openpub/>`__.
+
+:Rendered:
+   |today|
 
 .. Meta Menu
 

--- a/Documentation/IntroductionPackage/Index.rst
+++ b/Documentation/IntroductionPackage/Index.rst
@@ -31,19 +31,49 @@ Installing The Introduction Package
 
 To install the Introduction Package run the following command:
 
-.. code-block:: shell
-   :caption: ~$
+.. tabs::
 
-   composer require typo3/cms-introduction
+   .. group-tab:: bash
+
+       .. code-block:: bash
+
+         composer require typo3/cms-introduction
+
+   .. group-tab:: powershell
+
+       .. code-block:: powershell
+
+         composer require typo3/cms-introduction
+
+   .. group-tab:: ddev
+
+       .. code-block:: bash
+
+         ddev composer require typo3/cms-introduction
 
 This command will download and activate the extension.
 
 Then run:
 
-.. code-block:: shell
-   :caption: ~$
+.. tabs::
 
-   extension:setup
+   .. group-tab:: bash
+
+       .. code-block:: bash
+
+         vendor/bin/typo3 extension:setup
+
+   .. group-tab:: powershell
+
+       .. code-block:: powershell
+
+         vendor/bin/typo3 extension:setup
+
+   .. group-tab:: ddev
+
+       .. code-block:: bash
+
+         ddev typo3 extension:setup
 
 This will set up the extension ready for immediate use.
 


### PR DESCRIPTION
This commit moves meta information to the bottom
of the landing page. The intent being to only show the
most relevant information above the fold.