### PR TITLE
[TASK] Correct spelling of TYPO3 versions

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -27,7 +27,7 @@ We are currently working on optimizing the rendering. Due to this, there
 was an issue with rendering the translation. The translated version still
 exists in a separate branch **fr** and only needs to be reactivated once
 the issues with rendering have been solved and the French branch has been
-reviewed for TYPO3 9.
+reviewed for TYPO3 v9.
 
 
 .. _status:

--- a/Documentation/Installation/ReleaseIntegrity.rst
+++ b/Documentation/Installation/ReleaseIntegrity.rst
@@ -38,7 +38,7 @@ The file hashes for each version are published on get.typo3.org and can be found
 on the corresponding release page, for example https://get.typo3.org/version/11#package-checksums contains:
 
 .. code-block:: bash
-   :caption: TYPO3 11.5.1 Checksums
+   :caption: TYPO3 v11.5.1 Checksums
    :name: Checksums
 
    SHA256:

--- a/Documentation/SystemRequirements/Index.rst
+++ b/Documentation/SystemRequirements/Index.rst
@@ -43,4 +43,4 @@ Composer
 ========
 
 Composer is only required for **local** installations - see `https://getcomposer.org <https://getcomposer.org>`_ for further
-information. It is recommended to always use the latest available Composer version. TYPO3 11.5 LTS requires at least Composer version 2.1.0.
+information. It is recommended to always use the latest available Composer version. TYPO3 v11 LTS requires at least Composer version 2.1.0.


### PR DESCRIPTION
Related: TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument#295

Releases: main, 11.5