### PR TITLE
[TASK] Move deployment information out of installation chapter

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -9,40 +9,9 @@ Installing TYPO3
 ================
 
 Welcome to the TYPO3 installation guide. This guide covers each of the steps required
-to install TYPO3 using the dependency manager Composer.
+to install TYPO3 using Composer. Note that Composer should only be used to install TYPO3 on a local or development environment.
 
-Installation and deployment
----------------------------
-
-It is recommended to not use Composer on a productive system to update and install
-additional packages. Such changes should be made on a development system (locally in
-DDEV, on a non-productive part of the server, ...)
-
-This way it can be prevented to install unwanted versions of packages. The files
-:file:`composer.json` and :file:`composer.lock` can be kept under version control
-and specify exactly what versions should be installed.
-
-Deployment to the productive system can be achieved by deploying these two
-:file:`composer.*` files and calling
-
-.. code-block:: bash
-   :caption: /var/www/site/$
-
-   composer install --no-dev
-
-.. warning::
-   Always use the `--no-dev <https://getcomposer.org/doc/03-cli.md#install-i>`__ option to prevent installing packages marked as
-   "development only" to be deployed on the productive server.
-
-Or by executing the above command on a development system or in a Docker container
-in a deployment pipeline and then just transfer the following folders:
-
-.. code-block:: none
-
-   $ TYPO3 root directory
-   ├── webroot/typo3
-   ├── webroot/typo3conf
-   └── vendor
+For more information on how to deploy TYPO3 to a live environment, visit the :ref:`deploying TYPO3 <DeployTYPO3>` chapter.
 
 Pre-installation Checklist
 --------------------------


### PR DESCRIPTION
This commit reverts an earlier change that introduced
deployment information to the very beginning of the
installation guide. Detailed information on why / how we 
deploy TYPO3 without using Composer is already available in the
Deploying TYPO3 chapter.

[-] Revert changed
[+] Continue to remind users not use Composer in production