### PR TITLE
Use proven DDEV install technique that uses composer --no-install

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -55,8 +55,11 @@ Execute Composer Create-Project
            # Start the ddev instance
            ddev start
 
-           # Fetch a basic TYPO3 installation and its' dependencies
-           ddev composer create "typo3/cms-base-distribution:^11"
+           # Fetch a basic TYPO3 installation composer.json
+           ddev composer create "typo3/cms-base-distribution" --no-install -y
+           
+           # And do the installation
+           ddev composer install
 
 
 This command pulls down the latest release of TYPO3 and places it in the


### PR DESCRIPTION
The existing install doesn't work if mutagen is enabled, I'm not sure why, but see the failure at https://gist.github.com/rfay/ecc92d820f1432384bcbe4ef24d06543

But the DDEV technique on https://ddev.readthedocs.io/en/latest/users/quickstart/#typo3-composer-build always works.

Note that this also changes the `typo3/cms-base-distribution:^11` to just `typo3/cms-base-distribution` so it doesn't have to be maintained on next release.