### PR TITLE
Remove 'hash' from required PHP extensions list

### DIFF
--- a/Documentation/SystemRequirements/PHP.rst.txt
+++ b/Documentation/SystemRequirements/PHP.rst.txt
@@ -43,7 +43,6 @@ Required Extensions
 * **session**
 * **xml**
 * **filter**
-* **hash**
 * **SPL**
 * **standard**
 * **mbstring**


### PR DESCRIPTION
Extension "hash" is a PHP core built in and can't be disabled. It's always there, no need to list it.