### PR TITLE
Remove "mbstring" from required PHP extensions (TYPO3v11)

### DIFF
--- a/Documentation/SystemRequirements/PHP.rst.txt
+++ b/Documentation/SystemRequirements/PHP.rst.txt
@@ -45,7 +45,6 @@ Required Extensions
 * **filter**
 * **SPL**
 * **standard**
-* **mbstring**
 
 Depending on the use case, the following extensions may also be required:
 


### PR DESCRIPTION
In TYPO3v11 this is still optional and `symfony/polyfill-mbstring` used as fallback.