### PR TITLE
Add link to sitehandling / adding languages. 

### DIFF
--- a/Documentation/OtherBackendModules/BackendLocalization/Index.rst
+++ b/Documentation/OtherBackendModules/BackendLocalization/Index.rst
@@ -83,3 +83,9 @@ user.
    language if that user has already logged in at least once, as
    the language is kept in the user preferences. Such users will
    need to update their language themselves.
+
+
+..  seealso::
+    Configure :yaml:`typo3Language` to use custom languages in the frontend,
+    see :ref:`sitehandling-addinglanguages` for details.
+

--- a/Documentation/OtherBackendModules/BackendLocalization/Index.rst
+++ b/Documentation/OtherBackendModules/BackendLocalization/Index.rst
@@ -87,5 +87,5 @@ user.
 
 ..  seealso::
     Configure :yaml:`typo3Language` to use custom languages in the frontend,
-    see :ref:`sitehandling-addinglanguages` for details.
+    see :ref:`t3coreapi:sitehandling-addinglanguages` for details.
 


### PR DESCRIPTION
Add a related link for people who are looking for managing frontend translations - just like here: https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Localization/ManagingTranslations.html

I don't know if the ref works here, is there a way to preview how the `:ref:'sitehandling-addinglanguages'` will be rendered? 