### PR TITLE
Re-add mbstring PHP extension

### DIFF
--- a/Documentation/SystemRequirements/PHP.rst.txt
+++ b/Documentation/SystemRequirements/PHP.rst.txt
@@ -45,6 +45,7 @@ Required Extensions
 * **filter**
 * **SPL**
 * **standard**
+* **mbstring** (optional, but a huge performance boost)
 
 Depending on the use case, the following extensions may also be required:
 

--- a/Documentation/SystemRequirements/PHP.rst.txt
+++ b/Documentation/SystemRequirements/PHP.rst.txt
@@ -45,7 +45,6 @@ Required Extensions
 * **filter**
 * **SPL**
 * **standard**
-* **mbstring** (optional, but a huge performance boost)
 
 Depending on the use case, the following extensions may also be required:
 
@@ -55,6 +54,7 @@ Depending on the use case, the following extensions may also be required:
 * **zlib** (TYPO3 uses zlib for output compression)
 * **openssl** (OpenSSL is required for sending SMTP mails over an encrypted channel endpoint)
 * **intl** (when using unicode-based filesystems)
+* **mbstring** (optional, but a huge performance boost compared to the polyfill which is used otherwise)
 
 Required Database Extensions
 ----------------------------


### PR DESCRIPTION
php-mbstring ist optional because there is the fallback onto a polyfill. But for performance reasons it should be mentioned.

Example

Opening a EXT:news record with ~40 content elements attachached:
* without php-mbstring: ~40s response time
* with php-mbstring: ~1s response time