### PR TITLE
[TASK] Remove moving AdditionalConfiguration.php from ddev tab

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -64,10 +64,6 @@ At the root level of your web server, execute the following command:
             # Fetch a basic TYPO3 installation and its' dependencies
             ddev composer create "typo3/cms-base-distribution:^12"
 
-            # Depending on your DDEV version the configuration file may have been
-            # created in an outdated location, you can move it with
-            mkdir -p config/system/ && mv  public/typo3conf/AdditionalConfiguration.php $_/additional.php
-
 
 This command pulls down the latest release of TYPO3 and places it in the
 :file:`example-project-directory`.


### PR DESCRIPTION
When v12.0 came out ddev does not know about the moved file. Since that quite some ddev versions came out which can check the TYPO3 version and create the AdditionalConfiguration.php or the additional.php accordingly. So, the command to manually move the additional configuration can be removed.

Releases: main, 12.4