### PR TITLE
Add latest LTS version in download code

### DIFF
--- a/Documentation/Installation/LegacyInstallation.rst
+++ b/Documentation/Installation/LegacyInstallation.rst
@@ -20,7 +20,7 @@ Installing on a Unix Server
    .. code-block:: bash
       :caption: /var/www/site/$
 
-      wget --content-disposition https://get.typo3.org/11
+      wget --content-disposition https://get.typo3.org/12
 
    Ensure that the package is one level above the web server's document root.
 


### PR DESCRIPTION
As version 12.4 is used in the following code examples, it makes sense to remain consistent in this respect in the download code snippet.