### PR TITLE
[BUGFIX] Remove ".rst" endings from menues

### DIFF
--- a/Documentation/Extensions/Index.rst
+++ b/Documentation/Extensions/Index.rst
@@ -52,6 +52,6 @@ Working With Extensions
    :hidden:
    :titlesonly:
 
-   Management.rst
+   Management
    Installing Local Extensions <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Extensions/Management.html#installing-local-extensions>
-   LegacyManagement.rst
+   LegacyManagement

--- a/Documentation/Localization.ru_RU/Extensions/Index.rst
+++ b/Documentation/Localization.ru_RU/Extensions/Index.rst
@@ -49,6 +49,6 @@
    :hidden:
    :titlesonly:
 
-   Management.rst
+   Management
    Установка локальных расширений <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Extensions/Management.html#installing-local-extensions>
-   LegacyManagement.rst
+   LegacyManagement

--- a/Documentation/Localization.ru_RU/Setup/Index.rst
+++ b/Documentation/Localization.ru_RU/Setup/Index.rst
@@ -50,6 +50,6 @@
    :hidden:
    :titlesonly:
 
-   SiteRecords.rst
-   BackendUsers.rst
-   BackendLanguages.rst
+   SiteRecords
+   BackendUsers
+   BackendLanguages

--- a/Documentation/Localization.ru_RU/Troubleshooting/Index.rst
+++ b/Documentation/Localization.ru_RU/Troubleshooting/Index.rst
@@ -95,8 +95,8 @@
    :hidden:
    :titlesonly:
 
-   TYPO3.rst
-   SystemModules.rst
-   PHP.rst
-   WebServer.rst
-   Database.rst
+   TYPO3
+   SystemModules
+   PHP
+   WebServer
+   Database

--- a/Documentation/Setup/Index.rst
+++ b/Documentation/Setup/Index.rst
@@ -50,6 +50,6 @@ Setup
    :hidden:
    :titlesonly:
 
-   SiteRecords.rst
-   BackendUsers.rst
-   BackendLanguages.rst
+   SiteRecords
+   BackendUsers
+   BackendLanguages

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -95,8 +95,8 @@ Troubleshooting
    :hidden:
    :titlesonly:
 
-   TYPO3.rst
-   SystemModules.rst
-   PHP.rst
-   WebServer.rst
-   Database.rst
+   TYPO3
+   SystemModules
+   PHP
+   WebServer
+   Database


### PR DESCRIPTION
Sphinx allows this while it is not in the standard, the guides can currently not interpret it correctly

releases: main, 12.4, 11.5