### PR TITLE
[BUGFIX] Fix ru_RU localization rendering errors

### DIFF
--- a/Documentation/Localization.ru_RU/Index.rst
+++ b/Documentation/Localization.ru_RU/Index.rst
@@ -1,4 +1,4 @@
-.. include:: /Localization.ru_RU/Includes.rst.txt
+.. include:: /Includes.rst.txt
 ..  _start:
 
 ================================

--- a/Documentation/Localization.ru_RU/guides.xml
+++ b/Documentation/Localization.ru_RU/guides.xml
@@ -14,6 +14,7 @@
            copyright="since 2012 by the TYPO3 contributors"/>
 
   <inventory id="t3start11" url="https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/ru-ru/"/>
+  <inventory id="t3start12" url="https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/ru-ru/"/>
   <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
   <inventory id="t3editors" url="https://docs.typo3.org/m/typo3/tutorial-editors/main/ru-ru/"/>
   <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>


### PR DESCRIPTION
"render-guides" does not allow a full "/Path/" suffix, and t3start12 was missing