### PR TITLE
[TASK] Link to next instructions for Legacy Install section

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -168,6 +168,8 @@ Create an empty file called `FIRST_INSTALL` in the `public/` directory:
     ├── var
     └── vendor
 
+..  _install-access-typo3-via-a-web-browser:
+
 Access TYPO3 via a web browser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Installation/LegacyInstallation.rst
+++ b/Documentation/Installation/LegacyInstallation.rst
@@ -10,8 +10,8 @@ Legacy Installation
 
 ..  warning::
     This guide details how TYPO3 can be installed without using Composer. This method of installation
-    is now considered **out of date**, users are strongly encouraged to use the 
-    :ref:`Composer-based installation instructions <t3start:Installation/Install#install>`.
+    is now considered **out of date**, users are strongly encouraged to use the
+    :ref:`Composer-based installation instructions <install>`.
 
 Installing on a Unix Server
 ===========================
@@ -100,8 +100,8 @@ Completing The Installation
 ===========================
 
 After the source package has been extracted and the symlinks created, continue from the
-:doc:`Access TYPO3 via a web browser <t3start:Installation/Install#access-typo3-via-a-web-browser>` 
-section of the :ref:`instructions for installing TYPO3 using Composer <t3start:Installation/Install#install>` to 
+:ref:`Access TYPO3 via a web browser <install-access-typo3-via-a-web-browser>`
+section of the :ref:`instructions for installing TYPO3 using Composer <install>` to
 complete the installation.
 
 .. toctree::

--- a/Documentation/Installation/LegacyInstallation.rst
+++ b/Documentation/Installation/LegacyInstallation.rst
@@ -8,8 +8,10 @@
 Legacy Installation
 ===================
 
-This guide details how TYPO3 can be installed without using Composer. This method of installation
-is now considered out of date, users are strongly encouraged to use the Composer-based :ref:`install`
+..  warning::
+    This guide details how TYPO3 can be installed without using Composer. This method of installation
+    is now considered **out of date**, users are strongly encouraged to use the 
+    :ref:`Composer-based installation instructions <install>`.
 
 Installing on a Unix Server
 ===========================
@@ -97,8 +99,10 @@ Installing on a Windows Server
 Completing The Installation
 ===========================
 
-After the source package has been extracted and the symlinks created,
-visit the Access TYPO3 via web browser to complete the installation.
+After the source package has been extracted and the symlinks created, continue from the
+:doc:`Access TYPO3 via a web browser <access-typo3-via-a-web-browser>` 
+section of the :ref:`instructions for installing TYPO3 using Composer <install>` to 
+complete the installation.
 
 .. toctree::
    :hidden:

--- a/Documentation/Installation/LegacyInstallation.rst
+++ b/Documentation/Installation/LegacyInstallation.rst
@@ -11,7 +11,7 @@ Legacy Installation
 ..  warning::
     This guide details how TYPO3 can be installed without using Composer. This method of installation
     is now considered **out of date**, users are strongly encouraged to use the 
-    :ref:`Composer-based installation instructions <install>`.
+    :ref:`Composer-based installation instructions <t3start:Installation/Install#install>`.
 
 Installing on a Unix Server
 ===========================
@@ -100,8 +100,8 @@ Completing The Installation
 ===========================
 
 After the source package has been extracted and the symlinks created, continue from the
-:doc:`Access TYPO3 via a web browser <access-typo3-via-a-web-browser>` 
-section of the :ref:`instructions for installing TYPO3 using Composer <install>` to 
+:doc:`Access TYPO3 via a web browser <t3start:Installation/Install#access-typo3-via-a-web-browser>` 
+section of the :ref:`instructions for installing TYPO3 using Composer <t3start:Installation/Install#install>` to 
 complete the installation.
 
 .. toctree::


### PR DESCRIPTION
Adds a link from the end of the Legacy Install instructions to the "Access TYPO3 via a web browser" step in the standard instructions.

Also adds a warning admonition to the text about the Legacy Install instructions being out of date.