### PR TITLE
[TASK] Document SQL_MODE requirements / current state

### DIFF
--- a/Documentation/SystemRequirements/Database.rst.txt
+++ b/Documentation/SystemRequirements/Database.rst.txt
@@ -18,3 +18,23 @@ It is recommended to also grant the following privileges:
 * CREATE VIEW, SHOW VIEW
 
 * EXECUTE, CREATE ROUTINE, ALTER ROUTINE
+
+Some database systems like MySQL and MariaDB allow to configure
+SQL language support through a :sql`SQL_MODE` setting.
+
+TYPO3 strives to be compatible to the DEFAULT `SQL_MODE` settings
+of the database engine versions supported by a specific TYPO3 release.
+
+If you change any setting to a NON-default SQL mode, be prepared to
+audit all involved code to be compatible to your server mode choice.
+Notably the settings `ANSI` and `ANSI_QUOTES` may cause issues.
+
+`NO_AUTO_VALUE_ON_ZERO`, `NO_ENGINE_SUBSTITUTION`, `NO_AUTO_CREATE_USER`,
+`ERROR_FOR_DIVISION_BY_ZERO`, `ONLY_FULL_GROUP_BY`, `NO_ZERO_DATE`,
+`NO_ZERO_IN_DATE`, `STRICT_ALL_TABLES` and `STRICT_TRANS_TABLES` should
+work with TYPO3 versions 12 and upwards, as the internal tests are
+performed with the `SQL_MODE` set to those keys.
+
+Custom or third-party extensions need to be evaluated individually.
+
+Listed as being incompatible is: `NO_BACKSLASH_ESCAPES`.


### PR DESCRIPTION
This PR addresses a valid question from https://forge.typo3.org/issues/94100 to indicate which SQL_MODE settings
may be required. A small chat with @sbuerk revelead the current testing defaults which should be safe to mention here.

IMO further details can be clarified in a follow-up.

Releases: main, 12.4