### PR TITLE
[BUGFIX] Correct the DDEV configuration command for the current version

### DIFF
--- a/Documentation/Installation/TutorialDdev.rst
+++ b/Documentation/Installation/TutorialDdev.rst
@@ -55,15 +55,16 @@ of preconfigured projects.
 
     Project Type [php, typo3, ...] (php): typo3
 
-docroot
+Docroot Location
     Is the folder containing files that have to be reached by
     the webserver. It contains the vital entry point :file:`index.php`. The folder is commonly called :file:`public`.
 
-project-type
+Project Type
     Should always be "typo3"
 
-php-version
-    Should be set manually to the required PHP version in :file:`.ddev/config.yaml`.
+..  note::
+    The PHP version (:yaml:`php_version`) should be set manually to the required
+    version in :file:`.ddev/config.yaml`.
 
 Alternatively you can skip the prompt by supplying all of the required parameters in a single command:
 

--- a/Documentation/Installation/TutorialDdev.rst
+++ b/Documentation/Installation/TutorialDdev.rst
@@ -45,7 +45,7 @@ of preconfigured projects.
 
 ..  code-block:: bash
 
-    ddev config --php-version 8.2
+    ddev config
 
     # Give the following answers when prompted:
 
@@ -55,12 +55,15 @@ of preconfigured projects.
 
     Project Type [php, typo3, ...] (php): typo3
 
-project-type
-    Should always be "typo3"
-
 docroot
     Is the folder containing files that have to be reached by
     the webserver. It contains the vital entry point :file:`index.php`. The folder is commonly called :file:`public`.
+
+project-type
+    Should always be "typo3"
+
+php-version
+    Should be set manually to the required PHP version in :file:`.ddev/config.yaml`.
 
 Alternatively you can skip the prompt by supplying all of the required parameters in a single command:
 


### PR DESCRIPTION
The documented workflow doesn't work for ddev 1.23.3 anymore.
When the `--php-version` parameter is given, ddev doesn't ask for `type` and `docroot`.

Releases: main, 12.4, 11.5