### PR TITLE
Remove reference to composer/legacy in installation

### DIFF
--- a/Documentation/FirstProject/IntroductionPackage/Index.rst
+++ b/Documentation/FirstProject/IntroductionPackage/Index.rst
@@ -49,20 +49,6 @@ To install the Introduction Package run the following command:
 
             ddev composer require typo3/cms-introduction
 
-..  tabs::
-
-   ..  group-tab:: Composer-based installation
-
-      ..  code-block:: bash
-
-            vendor/bin/typo3 extension:setup
-
-   ..  group-tab:: Legacy installation
-
-        ..  code-block:: bash
-
-            typo3/sysext/core/bin/typo3 extension:setup
-
 Then run:
 
 ..  tabs::


### PR DESCRIPTION
Removes a set of tabs for "Composer-based installation" and "Legacy installation." These tabs repeat the content of the bash/powershell/ddev commands below. Also, the reference to legacy installation is unnecessary as bash/powershell/ddev all use Composer for installation.