### PR TITLE
Update Web Server Type

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -120,7 +120,7 @@ When prompted give the following answers to work with the default DDEV configura
 ..  code-block:: bash
 
     Which web server is used?
-    > apache
+    > other
 
     Database driver?
     > mysqli


### PR DESCRIPTION
DDEV supports nginx with php-fpm by default (nginx-fpm) so we need to choose "other", instead "apache" beacause choosing "apache" create a .htaccess file not used by nginx. And it could be confusing for tutorial follower.

Releases : main, 13.4