### PR TITLE
[TASK] Add info about how to support DDEV

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -20,6 +20,9 @@ Installation instructions <t3start12:install>`.
 
 ..  youtube:: HW7J3G1SqZw
 
+..  note::
+    Like TYPO3, DDEV is open source software that exists because of the generosity of community members and sponsors. Read more about `how to support DDEV <https://ddev.com/support-ddev/>`__.
+
 Pre-Installation Checklist
 --------------------------
 


### PR DESCRIPTION
Adds a note admonition to the Installing TYPO3 with DDEV page that informs about TYPO3 and DDEV's dependency on community and support.

Due to the recent announcement that DDEV has lost its lead sponsor, it is a nice gesture to remind TYPO3 documentation readers of the possibility to support DDEV.

This may be followed up with similar admonitions in relevant places, also concerning TYPO3 itself and other open source projects upon which our CMS relies.