### PR TITLE
Remove faulty link text in "The Filelist module" (Getting Started Tutorial)

### DIFF
--- a/Documentation/Concepts/Backend/FileModule/Index.rst
+++ b/Documentation/Concepts/Backend/FileModule/Index.rst
@@ -14,7 +14,6 @@ The Editors Guide describes how to
 Do not store :ref:`assets <assets>` needed for your theme here. Store these in
 the folder :path:`Resources/Public` of your :ref:`site package <creating-a-site-package>`
 or another :ref:`extension <create-own-extension>`.
-leuchtfeuer/secure-downloads
 
 .. _file-module-fileadmin:
 


### PR DESCRIPTION
It seems to me that this was overlooked, and that this (composer) link was intended to be used further down in the next paragraph (which has been done).