### PR TITLE
fix grammar and typos (TYPO3 concepts)

### DIFF
--- a/Documentation/Concepts/Assets/Index.rst
+++ b/Documentation/Concepts/Assets/Index.rst
@@ -54,11 +54,11 @@ Assets in extensions and site packages
 Assets usually include CSS files, JavaScript and images / icons used for design
 purposes.
 
-Within an extension, including a site package, they can only be placed in folder
-:path:`Resources/Public` and subfolders of this folder.
+Within an extension, including a site package, they can only be placed in the
+:path:`Resources/Public` folder and subfolders of this folder.
 
 During Composer installation the :path:`Resources/Public` directories of all
-installed extensions are symlinked into the webroot, folder :path:`public/_assets`.
+installed extensions are symlinked into the :path:`public/_assets` webroot folder.
 For security reasons the folders in :path:`public/_assets` have hashed names.
 
 ..  note::

--- a/Documentation/Concepts/Backend/AdminTools/ContentSecurityPolicy.rst
+++ b/Documentation/Concepts/Backend/AdminTools/ContentSecurityPolicy.rst
@@ -13,5 +13,5 @@ API.
 This module handles
 :ref:`Reporting of violations of the Content Security
 Policy <t3coreapi:content-security-policy-reporting>`. It is always available
-but can only be:ref:`accessed via the backend <t3start:admin-tools-access>`,
+but can only be :ref:`accessed via the backend <t3start:admin-tools-access>`,
 not the Install Tool.

--- a/Documentation/Concepts/Cache/Index.rst
+++ b/Documentation/Concepts/Cache/Index.rst
@@ -30,14 +30,14 @@ Here are the main ways to clear caches in TYPO3 13:
 *   Clearing Cache in the backend:
 
     *   In the Backend, look for the Clear cache icon, which resembles a
-        lightning bolt. You can find this in the top toolbar.
+        lightning bolt. You can find this in the `top bar <https://docs.typo3.org/permalink/t3start:top-bar>`_.
 
         .. figure:: /Images/ManualScreenshots/ClearCache/Toolbar.png
 
     *   For deeper cache management, you can use the Install Tool:
         In :guilabel:`Admin Tools > Maintenance` you can find the option to
         clear all caches. This will refresh everything, including caches
-        that aren't typically cleared through the backend toolbar.backend
+        that aren't typically cleared through the backend top bar.
 
 *   Clearing caches via Command Line
 

--- a/Documentation/Concepts/TCA/Index.rst
+++ b/Documentation/Concepts/TCA/Index.rst
@@ -33,8 +33,8 @@ TCA is used to:
     field to only accept numeric values or enforce a specific character limit.
 *   TCA supports defining relationships between tables, such as one-to-one, one-to-many, and many-to-many relations.
     It manages how records from related tables are linked and displayed in the backend.
-*   TCA, you can control which fields and records are editable, based on user roles and permissions.
-*   Extend existing tables and create new ones with custom field definitions
+*   TCA handles which fields and records are editable, based on user roles and permissions.
+*   TCA extends existing tables and creates new ones with custom field definitions
 
 For example, when you create a new content element or extend an existing one,
 you define the fields using TCA in the Configuration/TCA directory of your extension.

--- a/Documentation/Concepts/TypoScript/Index.rst
+++ b/Documentation/Concepts/TypoScript/Index.rst
@@ -124,7 +124,7 @@ Wrap "Hello, world." in p-tags
 6.  We use the :confval:`stdWrap <t3tsref:text-stdwrap>` property of the TEXT
     object to configure the :ref:`stdWrap <t3tsref:stdwrap>` function.
 
-    In this function we use the option wrap :confval:`wrap <t3tsref:stdwrap-wrap>`.
+    In this function we use the option :confval:`wrap <t3tsref:stdwrap-wrap>`.
     It surrounds the current content of the TEXT object as set in line 5 with
     the value defined here. The pipe `|` character is replaced by the text that corresponds to the value property.
 


### PR DESCRIPTION
- add missing space in sentence
- remove redundant words (I assume copy and paste errors)
- improve sentence structure
- use "top bar" wording instead of "toolbar" and add doc link (according to the [documentation](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Concepts/Backend/GeneralBackendStructure/TopBar/Index.html))