### PR TITLE
Fix Typos in Getting Started Tutorial

### DIFF
--- a/Documentation/Concepts/Backend/FileModule/Index.rst
+++ b/Documentation/Concepts/Backend/FileModule/Index.rst
@@ -47,12 +47,12 @@ All media and download files managed in the Filelist module are managed via
 an abstraction layer. You can find the documentation of this layer in TYPO3
 Explained, chapter :ref:`File abstraction layer (FAL) <t3coreapi:fal_introduction>`.
 
-On uploading, each file get a unique identifier assigned to
+On uploading, each file gets a unique identifier assigned to
 it. This identifier is used to link to files and also to attach meta data to
 them.
 
 This allows your editors to rename and move files without breaking the frontend.
-It also allows to test weather a file is still being used on deletion and to
+It also allows to test whether a file is still being used on deletion and to
 automatically delete unused media if desired.
 
 However you can only use the full power of the FAL if you do not link directly

--- a/Documentation/Installation/Updates/Index.rst
+++ b/Documentation/Installation/Updates/Index.rst
@@ -88,7 +88,7 @@ Minor updates
 -------------
 
 Minor changes - `11.*.2`: For example 11.5 has new functionalities compared to
-11.4. The version 11.5 is compatible with 11. So withing a version like major
+11.4. The version 11.5 is compatible with 11. So within a version like major
 11 the steps do not lead to breaking changes. For example in version 13.3
 compared to version 13.2 a new
 :ref:`Feature: #101252 - Introduce ErrorHandler for 403 errors with redirect option <changelog:feature-101252-1715447531>`

--- a/Documentation/Installation/Updates/Index.rst
+++ b/Documentation/Installation/Updates/Index.rst
@@ -35,7 +35,7 @@ you want to get further bugfixes you have to book an
 `extended support <https://typo3.com/services/extended-support-elts>`__ which usually costs money.
 
 Before we look a bit deeper into the :ref:`types of updates <getting-started-major-minor-patchlevel-updates>`
-we summaries how a TYPO3 user should act with respect to TYPO3 updates:
+we summarize how a TYPO3 user should act with respect to TYPO3 updates:
 
 * When a new major LTS version is released, users **should** focus on updating to this version as soon as possible.
 * When a new minor version is released, users **must** update to the new minor version, since the previous minor version is **not** supported any more.

--- a/Documentation/Prerequisites/Index.rst
+++ b/Documentation/Prerequisites/Index.rst
@@ -49,7 +49,7 @@ composer remove
 Uninstalls an existing package from your project.
 Removes the entry from :guilabel:`composer.json` and deletes related files from the
 :guilabel:`vendor` folder.
-Removes unused dependencies that were only required fro the removed package.
+Removes unused dependencies that were only required for the removed package.
 
 ..  _composer_install:
 


### PR DESCRIPTION
Replaces previous pull request made onto 13.4 branch. Per Stefan opening a new PR on main branch. Added a few additional typos from other document pages.