### PR TITLE
Updated DDEV steps

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -50,15 +50,7 @@ of preconfigured projects.
 
 ..  code-block:: bash
 
-    ddev config --php-version 8.3
-
-    # Give the following answers when prompted:
-
-    Project name (t3example):
-
-    Docroot Location (current directory): public
-
-    Project Type [php, typo3, ...] (php): typo3
+    ddev config --php-version 8.3 --docroot public --project-type typo3
 
 Docroot Location
     Is the folder containing files that have to be reached by
@@ -70,12 +62,6 @@ Project Type
 ..  note::
     The PHP version (:yaml:`php_version`) should be set manually to the required
     version in :file:`.ddev/config.yaml`.
-
-Alternatively you can skip the prompt by supplying all of the required parameters in a single command:
-
-..  code-block:: bash
-
-    ddev config  --project-type=typo3 --docroot=public --php-version 8.3
 
 Start the project
 -----------------


### PR DESCRIPTION
There will be no prompt on DDEV version v1.24.3.

`--auto` defaults to true and can not be turned of with another flag. As no structure is within the folder, it defaults to

> Configuring a 'php' project named 't3example' with docroot '' at './t3example'.

which is the wrong layout and project type.