### PR TITLE
[BUGFIX] Correct ref link to "create-root-page" in card footer

### DIFF
--- a/Documentation/FirstProject/Index.rst
+++ b/Documentation/FirstProject/Index.rst
@@ -33,7 +33,7 @@ In this chapter you will:
         Learn how to create the first page, the so called root page.
         It will be your future home page.
 
-        ..  card-footer:: :ref:`Create a root page <site-configuration>`
+        ..  card-footer:: :ref:`Create a root page <create-root-page>`
             :button-style: btn btn-secondary stretched-link
 
     ..  card:: :ref:`Create a new site configuration <site-configuration>`


### PR DESCRIPTION
The "Create a root page" link at the bottom of the "Root page" card of the "First project setup" page is now linking the the "Create root page" subpage. It was erroneously linking to "Site management". This was achieved by correcting the anchor reference.