### PR TITLE
update button text

### DIFF
--- a/Documentation/Concepts/Index.rst
+++ b/Documentation/Concepts/Index.rst
@@ -63,7 +63,7 @@ TYPO3 Concepts
         TypoScript is the basic configuration language used to configure the
         frontend output of a page in TYPO3.
 
-        ..  card-footer:: :ref:`Create a minimal page by pure TypoScript <typoscript>`
+        ..  card-footer:: :ref:`Create a minimal page using just TypoScript <typoscript>`
             :button-style: btn btn-secondary stretched-link
 
     ..  card:: TSconfig


### PR DESCRIPTION
This change removes a duplicate word and alters the appearance of the button—it no longer wraps and fits better with the headline of the linked page.