### PR TITLE
Add hint for BE login problems

### DIFF
--- a/Documentation/Troubleshooting/BackendLogin.rst
+++ b/Documentation/Troubleshooting/BackendLogin.rst
@@ -27,7 +27,9 @@ Login page reloads without error
 *   Check the cookies configuration in TYPO3: Ensure that cookie-related
     settings (:confval:`sessionTimeout <t3coreapi:globals-typo3-conf-vars-be-sessiontimeout>`,
     :confval:`cookieDomain <t3coreapi:globals-typo3-conf-vars-be-cookiedomain>`)
-    are correct and not causing session issues.
+    are correct and not causing session issues. Additionally, if 
+    `$GLOBALS[TYPO3_CONF_VARS][BE][cookieSameSite]  <https://docs.typo3.org/permalink/t3coreapi:confval-globals-typo3-conf-vars-be-cookiesamesite>`_
+    is set to "none", this only works HTTPS.
 
 ..  _troubleshooting-login-invalid:
 


### PR DESCRIPTION
Had this problem with TYPO3 v12 while experimenting with local test site. 
Usually, I hope, HTTPS will be used and sameSiteCookie not set to "none". But while setting up sites, certificates may not be available yet.
Unfortunately, there is no error message which may help in detecting cause of error.

Hope it will be helpful.

See also 

* https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Troubleshooting/BackendLogin.html#login-page-reloads-without-error
* https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/8.7.x/Feature-90351-ConfigureTYPO3-shippedCookiesWithSameSiteFlag.html
* https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/BE.html#confval-globals-typo3-conf-vars-be-cookiesamesite