### PR TITLE
Update TYPO3 setup command to include sitename

### DIFF
--- a/Documentation/Quickstart/_installation_ddev.sh
+++ b/Documentation/Quickstart/_installation_ddev.sh
@@ -12,7 +12,7 @@ ddev composer create-project "typo3/cms-base-distribution:^14"
 # Recommended: Require the default theme
 ddev composer req typo3/theme-camino
 # Run TYPO3 CLI setup (database credentials are pre-filled)
-ddev typo3 setup --server-type=other --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db --create-site
+ddev typo3 setup --server-type=other --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db --create-site <sitename>
 
 # Open the Backend login in a browser
 ddev launch /typo3/


### PR DESCRIPTION
When running command 

```
ddev typo3 setup --server-type=other --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db --create-site
```

I get the error

```
The "--create-site" option requires a value.
```