### PR TITLE
[BUGFIX] Fix broken changelog links in administration module badges

### DIFF
--- a/Documentation/Concepts/Backend/AdministrationModules/Index.rst
+++ b/Documentation/Concepts/Backend/AdministrationModules/Index.rst
@@ -9,8 +9,9 @@ Administration modules
 ======================
 
 ..  versionchanged:: 14.0
-    Most modules in this area have been moved from  :guilabel:`System`
-    to :guilabel:`Administration <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    Most modules in this area have been moved from :guilabel:`System`
+    to :guilabel:`Administration`. See `the changelog entry
+    <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`__.
 
 System modules are backend modules in the group "System"
 and they are only available to backend users with
@@ -29,8 +30,9 @@ Permissions
 ===========
 
 ..  versionchanged:: 14.0
-    This module has been moved from :guilabel:`System` to :guilabel:`Administration
-	<https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    This module has been moved from :guilabel:`System` to
+    :guilabel:`Administration`. See `the changelog entry
+    <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`__.
 
 In TYPO3, you can grant permissions to backend users.
 At first, a newly created backend user without any administrative
@@ -49,8 +51,9 @@ Backend Users
 =============
 
 ..  versionchanged:: 14.0
-    This module has been moved from :guilabel:`Administration` to :guilabel:`Administration`
-	<https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    This module has been moved from :guilabel:`System` to
+    :guilabel:`Administration`. See `the changelog entry
+    <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`__.
 
 The module :guilabel:`System > Users` is used to create, edit and delete
 backend users.
@@ -145,8 +148,9 @@ Reports (optional)
 ==================
 
 ..  versionchanged:: 14.0
-    This module has been moved from :guilabel:`System` to :guilabel:`Administration`
-	<https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    This module has been moved from :guilabel:`System` to
+    :guilabel:`Administration`. See `the changelog entry
+    <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`__.
 
 This module is only available if the system extension
 :composer:`typo3/cms-reports` is installed.


### PR DESCRIPTION
## Problem

On https://docs.typo3.org/permalink/t3start:administration-modules the "Changed in version 14.0" badges render a raw URL as literal text with a stray trailing underscore instead of a working link.

The cause is malformed RST: the notes try to combine a `:guilabel:` role with an embedded hyperlink.

```rst
to :guilabel:`Administration <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
```

`:guilabel:` is **not** a reference role, so the `` `name <url>`_ `` embedded-URI syntax is not interpreted — the whole content is shown verbatim and the trailing `_` is left dangling. Two of the blocks also indented the continuation line with a literal tab, and the Backend Users note wrongly read "moved from `Administration` to `Administration`".

## Fix

Split the badge from the link in all four `versionchanged` blocks: keep `:guilabel:` for the menu labels and add a separate "the changelog entry" hyperlink. Fix the Backend Users wording to "System to Administration" and replace the stray tabs with spaces.

```rst
to :guilabel:`Administration`. See `the changelog entry
<https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`__.
```

## Before / after

Top badge:

![Top badge before and after](https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Tutorial-GettingStarted/pr-assets/.pr-assets/before-after-top.png)

Backend Users badge (also fixes the "Administration → Administration" wording):

![Backend Users badge before and after](https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Tutorial-GettingStarted/pr-assets/.pr-assets/before-after-backendusers.png)

Rendered locally with `ghcr.io/typo3-documentation/render-guides:latest`; no warnings.
