### PR TITLE
[TASK] Update dependencies and adjust workflows for PHP 8.5

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,10 +12,10 @@ permissions:
 
 jobs:
   backport:
-    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@161f3bed5308099b67674e3e9d5a735e02500b24
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
     with:
       label_pattern: "^backport (.+)$"
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Composer validate
         run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerValidate
 
-      - name: Composer normalize
-        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerNormalize -n
-
       - name: CGL
         run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s cgl -n
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.2'
-          - '8.3'
-          - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -25,7 +23,7 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     env:
-      php: '8.2'
+      php: '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -61,11 +61,9 @@ Options:
 
         If not specified, podman will be used if available. Otherwise, docker is used.
 
-    -p <8.2|8.3|8.4>
+    -p <8.5>
         Specifies the PHP minor version to be used
-            - 8.2: (default) use PHP 8.2
-            - 8.3: use PHP 8.3
-            - 8.4: use PHP 8.4
+            - 8.5: (default) use PHP 8.5
     -n
         Only with -s cgl, composerNormalize, rector
         Activate dry-run in CGL check and composer normalize that does not actively change files and only prints broken ones.
@@ -79,7 +77,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 8.2
+    # Run unit tests using PHP 8.5
     ./Build/Scripts/runTests.sh
 EOF
 }
@@ -92,7 +90,7 @@ fi
 
 # Option defaults
 TEST_SUITE="cgl"
-PHP_VERSION="8.2"
+PHP_VERSION="8.5"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 CGLCHECK_DRY_RUN=0
@@ -120,7 +118,7 @@ while getopts "b:s:p:xy:nhu" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.2|8.3|8.4)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.5)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
       "typo3/cms-core": "dev-main as 14.3"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "~2.44.0",
         "friendsofphp/php-cs-fixer": "^3.46",
         "symfony/yaml": "^7.0",
         "typo3/cms-adminpanel": "dev-main as 14.3",


### PR DESCRIPTION
- Remove `ergebnis/composer-normalize` from dev dependencies.
- Update reusable backport workflow to use the `main` branch.
- Drop support for PHP versions 8.2, 8.3, and 8.4; default to PHP 8.5.
- Modify runTests script and workflow matrix to reflect PHP 8.5 changes.