### PR TITLE
Removed misleading TYPO3 extension replacement information

### DIFF
--- a/Documentation/Installation/Updates/Index.rst
+++ b/Documentation/Installation/Updates/Index.rst
@@ -117,9 +117,6 @@ you can enter the name of that extension and get information about supported TYP
 Some extension authors prefer to only publish their extensions on `packagist <https://packagist.org/packages/typo3/>`__.
 When the extension does not exist for the current TYPO3 version you can create an
 issue or search for an alternative extension offering the same functionality.
-For example, the `gridelements extension<https://extensions.typo3.org/extension/gridelements>`__
-was replaced by the `container extension<https://extensions.typo3.org/extension/container>`__, both
-having equal functionalities.
 
 Useful commands to simplify the updates of extensions can be found in the :ref:`Upgrade extensions guide <t3coreapi:upgradingextensions>`.
 


### PR DESCRIPTION
Removed example of a "replaced" TYPO3 extension, since both extensions still exist up to the latest LTS version of TYPO3 and are actively maintained.