### PR TITLE
[Backport 12.4] [BUGFIX] Restore sentence accidentally deleted in #841

### DIFF
--- a/Documentation/Installation/Updates/Index.rst
+++ b/Documentation/Installation/Updates/Index.rst
@@ -115,6 +115,7 @@ have to update the third-party extensions too. In the **`TYPO3 Extension Reposit
 you can enter the name of that extension and get information about supported TYPO3 versions.
 Some extension authors prefer to only publish their extensions on `packagist <https://packagist.org/packages/typo3/>`__.
 When the extension does not exist for the current TYPO3 version you can create an
+issue or search for an alternative extension offering the same functionality.
 For example, any blog extension could be replaced by another of several blog extensions.
 
 Useful commands to simplify the updates of extensions can be found in the :ref:`Upgrade extensions guide <t3coreapi:upgradingextensions>`.

--- a/Documentation/Installation/Updates/Index.rst
+++ b/Documentation/Installation/Updates/Index.rst
@@ -115,10 +115,7 @@ have to update the third-party extensions too. In the **`TYPO3 Extension Reposit
 you can enter the name of that extension and get information about supported TYPO3 versions.
 Some extension authors prefer to only publish their extensions on `packagist <https://packagist.org/packages/typo3/>`__.
 When the extension does not exist for the current TYPO3 version you can create an
-issue or search for an alternative extension offering the same functionality.
-For example, the `gridelements extension<https://extensions.typo3.org/extension/gridelements>`__
-was replaced by the `container extension<https://extensions.typo3.org/extension/container>`__, both
-having equal functionalities.
+For example, any blog extension could be replaced by another of several blog extensions.
 
 Useful commands to simplify the updates of extensions can be found in the :ref:`Upgrade extensions guide <t3coreapi:upgradingextensions>`.
 


### PR DESCRIPTION
Manual backport of #841 and #848 to 12.4.

PR #841 removed the outdated gridelements/container example but also
dropped the lead-in clause "issue or search for an alternative
extension offering the same functionality.", leaving a dangling
sentence fragment.

Signed-off-by: lina.wolf <lwolf@w-commerce.de>
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Releases: 12.4