### PR TITLE
[Backport 13.4] Update GitHub Actions workflow for whitespace fixes

### DIFF
--- a/.github/workflows/apply-precommit.yml
+++ b/.github/workflows/apply-precommit.yml
@@ -6,5 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  precommit:
+  fix-whitespace:
     uses: TYPO3-Documentation/.github/.github/workflows/reusable-apply-precommit.yml@main
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# Description
Backport of #820 to `13.4`.

Manual cherry-pick — the automatic backport failed because `13.4` never had
the `permissions:` block that the original commit replaces, so only the
`secrets:` hunk conflicted. The job rename (`precommit` → `fix-whitespace`)
applied cleanly.

`.github/workflows/apply-precommit.yml` is now byte-identical to the version
on `main` (and on `14.3`, which already carries this change). YAML parses
cleanly; no documentation files are touched.