### PR TITLE
[Backport 13.4] Update Index.rst

### DIFF
--- a/Documentation/Concepts/Backend/FileModule/Index.rst
+++ b/Documentation/Concepts/Backend/FileModule/Index.rst
@@ -71,7 +71,7 @@ For usage in PHP there is an API: :ref:`Working with files, folders and file
 references <t3coreapi:fal-using-fal-examples-file-folder>`
 
 ..  note::
-    Never link to a file in the fileadmin from CSS or or JavaScript. Such files
+    Never link to a file in the fileadmin from CSS or JavaScript. Such files
     like logos, icons, background images etc. should be stored as
     :ref:`Assets in extensions and site packages <assets>`.
 
@@ -80,7 +80,7 @@ references <t3coreapi:fal-using-fal-examples-file-folder>`
 File meta data
 ==============
 
-A number of meta data fields for media uploaded in the Filelist module is
+A number of meta data fields for media uploaded in the Filelist module are
 available out-of-the-box. Additional meta data fields are available if the
 system extension :composer:`typo3/cms-filemetadata` is installed.
 

--- a/Documentation/Concepts/Backend/ListModule/Index.rst
+++ b/Documentation/Concepts/Backend/ListModule/Index.rst
@@ -26,7 +26,7 @@ Display of database records in the List module
 
 How a database record type is displayed in the list module is determined by
 :ref:`tca` and can be further configured by TSconfig. While TCA is always loaded
-globally Tsconfig can be included on a per-site or per-page level.
+globally, TSconfig can be included on a per-site or per-page level.
 
 ..  todo: Link tsconfig once article exists in concepts.
 
@@ -85,5 +85,5 @@ set globally in the :ref:`tca` by setting a custom default value in TSconfig
     # Do not hide newly created pages by default
     TCAdefaults.pages.hidden = 0
 
-    # Set the author of a news to "Anonymous"
+    # Set the author of a news record to "Anonymous"
     TCAdefaults.tx_news_domain_model_news.author = Anonymous

--- a/Documentation/Concepts/Backend/SiteManagement/PageTSconfig.rst
+++ b/Documentation/Concepts/Backend/SiteManagement/PageTSconfig.rst
@@ -22,8 +22,8 @@ called :file:`EXT:my_extension/Configuration/page.tsconfig` or inserted or
 included in the record of a page in the page properties. Doing so is still
 possible for backward compatibility reasons.
 
-If you included the Page TSconfig via a site set or globally it
-not displayed in the overview submodule.
+If you included the Page TSconfig via a site set or globally, then it
+will not be displayed in the overview submodule.
 
 This does not mean it is not being loaded.
 
@@ -42,7 +42,7 @@ Included page TSconfig
 This module works much like :ref:`site-management-typoscript-included`, however
 the sources from which TSconfig is being loaded are different.
 
-In this Guide we assume that you load page TSconfig via the the site set of your
+In this Guide we assume that you load page TSconfig via the site set of your
 site package. The TSconfig Reference gives you an overview of all possible
 strategies to set page TSconfig:
 :ref:`Setting page TSconfig <t3tsref:setting-page-tsconfig>`.

--- a/Documentation/Concepts/Backend/SiteManagement/TypoScript.rst
+++ b/Documentation/Concepts/Backend/SiteManagement/TypoScript.rst
@@ -12,15 +12,15 @@ that you provided via your site as described in
 or via your site set as described in the Site Package Tutorial, chapter
 :ref:`The TypoScript-only version <t3sitepackage:make-typoscript-available>`.
 
-Before TYPO3 v13 TypoScript was managed via database records, called "TypoScript
-records". It is still possible doing this and you will see it in older examples
-or installations that have been updated and not refactored. This module can
-also be used to manage TypoScript records. Its usage is described in
-TypoScript Reference, chapter
+Before TYPO3 v13, TypoScript was set in database records called "TypoScript
+records". It is still possible to do this, and you will see it in older documentation
+and installations that have been updated but not yet refactored. The TypoScript
+backend module can be used to manage these TypoScript records, see
+the TypoScript Reference in chapter
 :ref:`TypoScript backend module <t3tsref:typoscript-syntax-typoscript-templates-structure>`.
 
-In the context of this guide we concentrate on the new way of providing TypoScript
-via the site only.
+In the context of this guide, we concentrate on the new way of providing TypoScript
+via the site.
 
 The TypoScript module consists of the following submodules. You can switch them
 in the docheader:
@@ -39,7 +39,7 @@ TypoScript Overview
 ===================
 
 Global overview of all pages with active TypoScript definitions (TypoScript
-records and site sets). Useful if you have more then one site or more then one
+records and site sets). Useful if you have more than one site or more than one
 TypoScript record in one site.
 
 ..  _site-management-typoscript-constant-editor:
@@ -47,12 +47,12 @@ TypoScript record in one site.
 Constant Editor
 ===============
 
-Before site settings were introduced with TYPO3 13, TypoScript constants where
-used to define values once and reuse them across TypoScript definitions.
+Before site settings were introduced in TYPO3 13, TypoScript constants were
+values that were defined in one place that could then be reused across TypoScript definitions.
 
-Constants can still be used for backward compatibility reasons but the
-Constant Editor is not available if you are using site sets. Other
-then site settings, TypoScript constants are only available within TypoScript.
+Constants can still be used for backward compatibility reasons, but the
+Constant Editor is not available if you are using site sets. Unlike
+site settings, TypoScript constants are only available in TypoScript.
 
 It is therefore recommended to always use site settings.
 
@@ -61,9 +61,10 @@ It is therefore recommended to always use site settings.
 Edit TypoScript record
 ======================
 
-Only available if TypoScript records are being used. Can be used to edit those
-records. As we manage TypoScript within the site in this Guide it is out of
-scope of this Guide. Its usage is described in the TypoScript reference,
+Only available if TypoScript records are being used. This module can be used to
+edit those records. Since this guide focuses on managing TypoScript within the site,
+this module is out of scope. For further information about TypoScript records,
+see the TypoScript reference,
 chapter :ref:`Submodule "Edit TypoScript Record" <t3tsref:typoscript_module_edit>`.
 
 ..  _site-management-typoscript-active:
@@ -71,14 +72,14 @@ chapter :ref:`Submodule "Edit TypoScript Record" <t3tsref:typoscript_module_edit
 Active TypoScript
 =================
 
-This module can be used to debug the active TypoScript. During loading and
-pre compiling TypoScript configuration can override or unset definitions made in
+This module can be used to debug active TypoScript. During loading and
+pre-compiling, TypoScript configuration can override or unset definitions made in
 another file.
 
 How exactly this happens depends on things like dependencies between the used
 site sets.
 
-For example if a site set in your site package configures:
+For example, if a site set in your site package configures:
 
 ..  code-block:: typoscript
     :caption: EXT:site_package/Configuration/Sets/SitePackage/setup.typoscript
@@ -86,7 +87,7 @@ For example if a site set in your site package configures:
     page.20 = TEXT
     page.20.value = Apple
 
-And the set of another extensions configures:
+And the set of another extension configures:
 
 ..  code-block:: typoscript
     :caption: EXT:some_extension/Configuration/Sets/BananaSet/setup.typoscript
@@ -94,7 +95,7 @@ And the set of another extensions configures:
     page.20 = TEXT
     page.20.value = Banana
 
-It depends on how these sets are loaded weather the `page.20.value` ends up
+It depends on how these sets are loaded whether the `page.20.value` ends up
 being set to "Banana" or "Apple".
 
 If the site set of our site package **depends** on the Banana set, the


### PR DESCRIPTION
# Description
Backport of #827 to `13.4`.

Manual cherry-pick — the automatic backport failed because two of the four
files were renamed on `main`. Git resolved the renames itself:

*   `Concepts/Backend/MediaModule/Index.rst` → `Concepts/Backend/FileModule/Index.rst`
*   `Concepts/Backend/RecordsModule/Index.rst` → `Concepts/Backend/ListModule/Index.rst`

`ListModule/Index.rst` and both `SiteManagement` files applied cleanly.
`FileModule/Index.rst` had two conflicts, because `main` carries wording
changes on those same lines that are unrelated to #827. Comparing against the
state of `main` immediately before #827 shows it changed exactly two things,
and only those were taken:

*   `CSS or or JavaScript` → `CSS or JavaScript`
*   `... module is available out-of-the-box` → `... module are available out-of-the-box`

`13.4`'s own wording was kept in both places — in particular "meta data
fields for media uploaded in the **Filelist** module", since the module is
only called "Media" from v14 on. The comma in `background images, etc.` and
the `metadata` spelling are likewise pre-existing on `main` and were not
pulled in.

`make test-docs` passes.