### PR TITLE
[BUGFIX] Fix the dead link to the TYPO3 Security Team

### DIFF
--- a/Documentation/NextSteps/Index.rst
+++ b/Documentation/NextSteps/Index.rst
@@ -60,9 +60,10 @@ Keep Security In Mind
 =====================
 
 Security is taken very seriously by the developers of TYPO3. The
-`TYPO3 Security Team <http://typo3.org/teams/security/>`_ manage all security
-incidents. They review them and consider their impact. Security advisories
-are regularly published.
+`TYPO3 Security Team
+<https://typo3.community/contribute/teams-committees/security>`_ manage all
+security incidents. They review them and consider their impact. Security
+advisories are regularly published.
 
 More information about security can be found in the
 :ref:`t3coreapi:security`.


### PR DESCRIPTION
http://typo3.org/teams/security/ returns 404 and is plain HTTP. The team
page now lives on the separate typo3.community domain, at
/contribute/teams-committees/security, which returns 200.

typo3.org/community/teams/security redirects there as well, but the
/community/ redirect does not cover every path below it, so the final URL
is used directly. The paragraph is rewrapped to stay below 80 characters.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
