### PR TITLE
[TASK] Add the missing captions to six literalinclude blocks

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -35,6 +35,7 @@ The following commands will create a new TYPO3 project, initialize DDEV, install
 TYPO3 via Composer, and run the setup. Copy and paste them into your terminal.
 
 ..  literalinclude:: /Quickstart/_installation_ddev.sh
+    :caption: /var/www/$ (DDEV)
     :language: bash
 
 Next steps: `TYPO3 setup on first installation <https://docs.typo3.org/permalink/t3start:typo3-setup>`_

--- a/Documentation/Quickstart/Index.rst
+++ b/Documentation/Quickstart/Index.rst
@@ -34,11 +34,13 @@ or a Linux system with a web server (Apache or Nginx), a database,
     ..  group-tab:: DDEV
 
         ..  literalinclude:: /Quickstart/_installation_ddev.sh
+            :caption: /var/www/$ (DDEV)
             :language: bash
 
     ..  group-tab:: Linux
 
         ..  literalinclude:: /Quickstart/_installation_linux.sh
+            :caption: /var/www/$ (Linux)
             :language: bash
 
 The directory in which you run these commands must be empty.
@@ -223,11 +225,13 @@ Copy the default theme:
     ..  group-tab:: Composer mode
 
         ..  literalinclude:: /Quickstart/_copy_theme_composer.sh
+            :caption: /var/www/site/$ (Composer mode)
             :language: bash
 
     ..  group-tab:: Classic mode
 
         ..  literalinclude:: /Quickstart/_copy_theme_classic.sh
+            :caption: /var/www/site/$ (Classic mode)
             :language: bash
 
         ..  figure:: /Images/ManualScreenshots/Quickstart/site_setup.png
@@ -250,6 +254,7 @@ You can use the development extension :composer:`friendsoftypo3/kickstarter`
 to create a custom theme that extends the default theme:
 
 ..  literalinclude:: /Quickstart/_extend_theme_composer.sh
+    :caption: /var/www/site/$
     :language: bash
 
 Edit the newly created :file:`packages/theme_pluto/composer.json` and update


### PR DESCRIPTION
Twice the Quickstart shows two scripts one under the other that do the
same thing for different setups — DDEV against Linux for the installation,
Composer mode against Classic mode for copying the theme. Which is which
was only visible in the name of the included snippet, which the reader
never sees.

The captions use the prompt this manual already uses, /var/www/site/$ for
commands inside the project, and name the variant. The three installation
scripts create the project directory, so their prompt is the level above.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
