### PR TITLE
[Backport 13.4] [TASK] Add the missing captions to six literalinclude blocks

### DIFF
--- a/Documentation/Installation/Install.rst
+++ b/Documentation/Installation/Install.rst
@@ -35,6 +35,7 @@ The following commands will create a new TYPO3 project, initialize DDEV, install
 TYPO3 via Composer, and run the setup. Copy and paste them into your terminal.
 
 ..  code-block:: bash
+    :caption: /var/www/$ (DDEV)
 
     # Create project directory
     mkdir my_project && cd my_project


### PR DESCRIPTION
Twice the Quickstart shows two scripts one under the other that do the
same thing for different setups — DDEV against Linux for the installation,
Composer mode against Classic mode for copying the theme. Which is which
was only visible in the name of the included snippet, which the reader
never sees.

The captions use the prompt this manual already uses, /var/www/site/$ for
commands inside the project, and name the variant. The three installation
scripts create the project directory, so their prompt is the level above.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf

Backport of #868 to 13.4.

One of the six captions applies. The Quickstart chapter does not exist on
this branch, and Installation/Install.rst spells its commands out in a
code-block instead of including a snippet, so the caption is added to
that block — same sentence, different directive.
