### PR TITLE
[TASK] Indent with spaces, not a tab

### DIFF
--- a/Documentation/Administration/BackendUsers/Administrator.rst
+++ b/Documentation/Administration/BackendUsers/Administrator.rst
@@ -120,7 +120,7 @@ Granting System Maintainer rights
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Using the module :guilabel:`System > Settings` and card
 "Manage System Maintainers Access" you can manage which administrator accounts

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/ContentSecurityPolicy.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/ContentSecurityPolicy.rst
@@ -10,7 +10,7 @@ Content Security Policy (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 :ref:`Content Security Policy <t3coreapi:content-security-policy>` declarations
 can be applied to a TYPO3 website in frontend and backend scope with a dedicated

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/Environment.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/Environment.rst
@@ -10,7 +10,7 @@ Environment (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Only available if :composer:`typo3/cms-install` is installed.
 

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/Extensions.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/Extensions.rst
@@ -10,7 +10,7 @@ Extensions (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Only available if :composer:`typo3/cms-extensionmanager` is installed.
 

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/Maintenance.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/Maintenance.rst
@@ -10,7 +10,7 @@ Maintenance (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Only available if :composer:`typo3/cms-install` is installed.
 

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/Settings.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/Settings.rst
@@ -10,7 +10,7 @@ Settings (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Only available if :composer:`typo3/cms-install` is installed.
 

--- a/Documentation/Concepts/Backend/SystemMaintainerArea/Upgrade.rst
+++ b/Documentation/Concepts/Backend/SystemMaintainerArea/Upgrade.rst
@@ -10,7 +10,7 @@ Upgrade (System)
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Only available if :composer:`typo3/cms-install` is installed.
 

--- a/Documentation/FirstProject/Settings.rst
+++ b/Documentation/FirstProject/Settings.rst
@@ -30,7 +30,7 @@ Global extension settings
 
 ..  versionchanged:: 14.0
     This module has been moved from :guilabel:`Admin tools` to :guilabel:`System`
-	see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
+    see `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_.
 
 Global settings for installed extensions, including some that are part of a
 default installation, can be made in the


### PR DESCRIPTION
Eight pages carry the same copied block, and in it the line pointing at
the changelog entry is indented with a tab while everything around it
uses four spaces. The .editorconfig of this repository asks for spaces.

Nothing changes in the output — a tab counts as deeper indentation, so
the line already belonged to the directive.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
