### PR TITLE
[TASK] Adopt the shared .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,29 +1,32 @@
 # EditorConfig is awesome: https://EditorConfig.org
-#
-# Use as master: https://github.com/TYPO3-Documentation/T3DocTeam/blob/main/.editorconfig
 
-# top-most EditorConfig file
+# Master copy, used unchanged by every TYPO3 documentation repository:
+# https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument
+
 root = true
 
+# Code examples indent two spaces, whatever the language, so that a nested
+# example still fits the line length the prose around it is wrapped to
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# reStructuredText is the exception: one indentation level is four spaces
 [{*.rst,*.rst.txt}]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
 indent_size = 4
 max_line_length = 80
 
-# MD-Files
 [*.md]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
-indent_size = 4
 max_line_length = 80
 
-[Makefile]
-# Use tabs for indentation (Makefiles require tabs)
+# Makefiles do not work without real tabs
+[{Makefile,_Makefile,**.mk}]
 indent_style = tab
+
+# In a patch a leading or trailing space is content, not whitespace
+[*.diff]
+trim_trailing_whitespace = false


### PR DESCRIPTION
The file is maintained in one place now, the How to Document guide, and
copied out unchanged. This repository's copy pointed at a master in
T3DocTeam that no longer describes what we do.

What changes here: code examples indent two spaces instead of four, so
that a nested example still fits the 80 characters the prose around it
is wrapped to. reST keeps four, because there the indentation is
structure rather than code. The Makefile section covers **.mk as well,
and a .diff is no longer stripped of trailing whitespace, which in a
patch is content rather than whitespace.

Nothing is reformatted by this commit. The file states the rule;
bringing the existing examples in line follows separately, together with
the php-cs-fixer setting that would otherwise revert them.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
